### PR TITLE
integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ sudo apt install \
   libboost-log-dev \
   libboost-system-dev \
   libserial-dev \
-  meson \
   ninja-build
+pip3 install --upgrade meson
 ```
 
 # Installation:

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -1,6 +1,10 @@
 #ifndef D3ABA1AA_24C9_45F8_8A86_453EAE0B0388
 #define D3ABA1AA_24C9_45F8_8A86_453EAE0B0388
 
-#define PTZF_VERSION "@version@"
+namespace ptzf {
+
+const char VERSION[] = "@version@";
+
+}  // namespace ptzf
 
 #endif /* D3ABA1AA_24C9_45F8_8A86_453EAE0B0388 */

--- a/include/controller.h
+++ b/include/controller.h
@@ -1,15 +1,13 @@
 #ifndef C540D9D8_4FC5_4163_BA5C_7C2BB87EFD0E
 #define C540D9D8_4FC5_4163_BA5C_7C2BB87EFD0E
 
+#include "position.h"
+
 #include <mutex>
 #include <string>
 #include <thread>
 
 #include <SerialStream.h>
-
-#include "utils.h"
-
-using std::experimental::optional;
 
 namespace ptzf {
 
@@ -43,7 +41,7 @@ class Controller {
 
   /**
    * @return true if printer/camera is connected.
-   * 
+   *
    * Note: currently this cannot fail. It is not required to disconnect
    * normally. The internal stream destructor should do that.
    */

--- a/include/meson.build
+++ b/include/meson.build
@@ -11,7 +11,6 @@ ptzf_incdir = include_directories('.')
 install_headers(
   'controller.h',
   'position.h',
-  'utils.h',
   config_h,
   subdir: meson.project_name(),
 )

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('ptzf', ['cpp'],
   version: run_command(
     'head', '-n', '1', files('VERSION'),
   ).stdout().strip(),
-  meson_version: '>= 0.49.0',
+  meson_version: '>= 0.55.0',
   license: 'LGPL',
   default_options: [
     'cpp_std=c++14',

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -14,7 +14,7 @@ const char OK_CODE[] = "ok P63 B31";
 /**
  * code to indicate printer is busy
  */
-const char BUSY_CODE[] = "echo:busy: processing";
+const char BUSY_CODE[] = "echo:busy:";
 
 /**
  * cstring to listen for when error occurs.

--- a/test/integration_controller.cpp
+++ b/test/integration_controller.cpp
@@ -1,8 +1,12 @@
 #include "controller.h"
+#include "utils.h"
+
 #include "gtest/gtest.h"
 
 #include <boost/log/core.hpp>
 #include <boost/log/expressions.hpp>
+
+#include <experimental/optional>
 
 namespace ptzf {
 namespace {
@@ -40,17 +44,20 @@ class ControllerTest : public ::testing::Test {
 };
 
 // Tests that the Foo::Bar() method does Abc.
-TEST_F(ControllerTest, InteractiveTest) {
+TEST_F(ControllerTest, SlowTest) {
   Controller c("/dev/SKR");
-  // TODO(mdegans): figure out extents
-  Position min_values{0.0f, 0.0f, 0.0f, 0.0f};
-  Position max_values{96.0f, 42.0f, 47.0f, 12.0f};
+  // @lackdaz you can add/remove positions to tests here
+  Position positions[] = {
+      Position{100.0f, 0.0f, 0.0f, 0.0f},  Position{0.0f, 0.0f, 0.0f, 0.0f},
+      Position{0.0f, 50.0f, 0.0f, 0.0f},   Position{0.0f, 0.0f, 0.0f, 0.0f},
+      Position{100.0f, 50.0f, 0.0f, 0.0f}, Position{100.0f, 0.0f, 0.0f, 0.0f},
+      Position{100.0f, 50.0f, 0.0f, 0.0f}, Position{0.0f, 50.0f, 0.0f, 0.0f},
+      Position{100.0f, 50.0f, 0.0f, 0.0f}, Position{0.0f, 0.0f, 0.0f, 0.0f},
+  };
 
-  ASSERT_TRUE(c.go(min_values));
-  ASSERT_TRUE(c.go(max_values));
-  ASSERT_TRUE(c.go(min_values));
-  ASSERT_TRUE(c.go(max_values));
-  ASSERT_TRUE(c.go(min_values));
+  for (const auto& p : positions) {
+    ASSERT_TRUE(c.go(p));
+  }
 }
 
 }  // namespace

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,7 +1,9 @@
 ext = '.cpp'
-basenames = [
+unit_tests = []
+integration_tests = [
   'controller'
 ]
+
 
 # googletest subproject stuff
 gtest_proj = subproject('gtest')
@@ -11,12 +13,34 @@ test_deps = [
   dependency('boost', modules: ['system']),
 ]
 
-foreach basename : basenames
+# run unit tests with default timeout
+foreach basename : unit_tests
   test_file = files('test_' + basename + ext)
   exe = executable('test_' + basename, test_file,
     dependencies: [ptzf_deps, test_deps],
     include_directories: ptzf_incdir,
     link_with: libptzf,
   )
-  test('test ' + basename + ext, exe)
+  test('test ' + basename + ext, exe,
+    suite: 'unit',
+    protocol: 'gtest',
+    env: [],
+  )
+endforeach
+
+# run integration tests with large timout
+foreach basename : integration_tests
+  test_file = files('integration_' + basename + ext)
+  exe = executable('integration_' + basename, test_file,
+    dependencies: [ptzf_deps, test_deps],
+    include_directories: ptzf_incdir,
+    link_with: libptzf,
+  )
+  test('integration ' + basename + ext, exe, 
+    suite: 'integration',
+    is_parallel: false, # the tests will break on parallel run
+    protocol: 'gtest',
+    timeout: 240,  # seconds
+    env: [],
+  )
 endforeach


### PR DESCRIPTION
* remove export of utils header
* separate integration and unit tests
* use gtest parser (require meson 0.55)
* better busy signal code